### PR TITLE
Add support for a wildcard visitor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { toIdentifier, toNode } from './utils';
 
 export const SKIP = true;
 export const REMOVE = false;
+export const ANY = '*';
 
 export function walk(node, visitor, state, parent) {
 	if (!node) return;
@@ -24,7 +25,7 @@ export function walk(node, visitor, state, parent) {
 	if (!type) return node;
 
 	let key, item, xyz;
-	let block = visitor[type];
+	let block = visitor[type] || visitor[ANY];
 
 	if (node.path === void 0) {
 		node.path = { parent };

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ const ENUM = suite('ENUM');
 
 ENUM('SKIP', () => assert.is(astray.SKIP, true));
 ENUM('REMOVE', () => assert.is(astray.REMOVE, false));
+ENUM('ANY', () => assert.is(astray.ANY, '*'));
 
 ENUM.run();
 

--- a/test/walk.js
+++ b/test/walk.js
@@ -93,6 +93,24 @@ walk('should update Node item after visitor mutations', () => {
 	assert.not.equal(program, copy);
 });
 
+walk('should call a wildcard visitor', () => {
+	let concrete = false;
+	let wildcard = false;
+	const program = parse(`var hello = 'world';`);
+	astray.walk(program, {
+		Program(node) {
+			assert.ok(node === program);
+			concrete = true;
+		},
+		[astray.ANY](node) {
+			assert.ok(node !== program);
+			wildcard = true;
+		}
+	});
+	assert.ok(concrete, '~> concrete visitor');
+	assert.ok(wildcard, '~> wildcard visitor');
+});
+
 walk.run();
 
 // ---


### PR DESCRIPTION
Recognise a visitor with the key ANY ('*') and call it if there is no visitor for a concrete node type available.

This should have no noticeable effect on the performance.

Attempts to fix #3.